### PR TITLE
Fix typo in building-status.rkt

### DIFF
--- a/building-status.rkt
+++ b/building-status.rkt
@@ -16,7 +16,7 @@
 ;; - "old"
 ;; - "heritage"
 ;; interp. status of buildings age
-;; examples are redundant for enumirations
+;; examples are redundant for enumerations
 
 (@dd-template-rules one-of            ;3 cases
                     atomic-distinct   ; "new"


### PR DESCRIPTION
Fix typo on line 19 from 'enumirations' to 'enumerations'